### PR TITLE
added support for native SEED_RANDOM function and expanded list and var handling and variable divert sort of supported

### DIFF
--- a/inkdc/StoryDecompiler.cs
+++ b/inkdc/StoryDecompiler.cs
@@ -730,6 +730,10 @@ namespace inkdc
                     {
                         BuildFunctionCall(stack, "TURNS_SINCE", 1);
                     }
+                    else if (controlCommand.commandType == ControlCommand.CommandType.SeedRandom)
+                    {
+                        BuildFunctionCall(stack, "SEED_RANDOM", 1);
+                    }
                     else if (controlCommand.commandType == ControlCommand.CommandType.Random)
                     {
                         BuildFunctionCall(stack, "RANDOM", 2);


### PR DESCRIPTION
don't know if you're still interested in maintaining this decompiler. (forgive me for my sins with the expanded list/var handling. it's ugly/terrible but it works)

another thing I found for diverts where the script hangs is that variable diverts can also have functions as the value of the variable instead of a path. 
I'm sadly not good enough in coding to fix it, so I'm hoping you could take a look at it if you're still somewhat interested. Sorry for putting this in a pull request as there is no issues page, and your fork is the most recently updated.
EDIT: seems to also happen with variable divert paths in arguments not just the functions
EDIT2: got it sort of working. sadly I think this the end of what I can achieve in fixing or making some things work I've been looking at. Like labeled gathers and options and some other things I can't find the name for currently